### PR TITLE
uprobe支持没有名字的so库

### DIFF
--- a/link/kprobe.go
+++ b/link/kprobe.go
@@ -250,6 +250,9 @@ func pmuProbe(args tracefs.ProbeArgs) (*perfEvent, error) {
 			Config: config,              // Retprobe flag
 		}
 	case tracefs.Uprobe:
+		if strings.Contains(args.Path, "!") {
+			args.Path = strings.Split(args.Path, "!")[0]
+		}
 		sp, err = unsafeStringPtr(args.Path)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
cilium/ebpf似乎没法对非ELF格式的文件使用uprobe.需要patch.